### PR TITLE
Draw frigate holes with thin dashed lines in the system graph

### DIFF
--- a/trackers/site/app.py
+++ b/trackers/site/app.py
@@ -549,6 +549,7 @@ def graph():
                     'id': wh.id,
                     'mass': wh.get_type_js(),
                     'count': get_player_count_in_system(wh.end),
+                    'tiny': wh.tiny,
                 })
                 return True
             if c['name'] == get_system_name(wh.end):
@@ -560,6 +561,7 @@ def graph():
                     'id': wh.id,
                     'mass': wh.get_type_js(),
                     'count': get_player_count_in_system(wh.start),
+                    'tiny': wh.tiny,
                 })
                 return True
             if append_connection(c['connections'], wh):
@@ -580,7 +582,7 @@ def graph():
         else:
             return 'nullsec'
     class GraphWormhole(object):
-        def __init__(self, id=0, start='', end='', status='', start_class='', start_sec='', end_clazz='', end_sec=''):
+        def __init__(self, id=0, start='', end='', status='', start_class='', start_sec='', end_clazz='', end_sec='', tiny=False):
             self.id = id
             self.start = start
             self.end = end
@@ -589,6 +591,7 @@ def graph():
             self.start_sec = start_sec
             self.end_clazz = end_clazz
             self.end_sec = end_sec
+            self.tiny = tiny
         def get_type_js(self):
             if self.status in ['Undecayed', 'Fresh']:
                 return 'good'
@@ -602,7 +605,7 @@ def graph():
 
     wormholes = []
     for wormhole in Wormhole.query.filter_by(opened=True, closed=False):
-        g = GraphWormhole(id=wormhole.id, start=wormhole.start, end=wormhole.end, status=wormhole.status)
+        g = GraphWormhole(id=wormhole.id, start=wormhole.start, end=wormhole.end, status=wormhole.status, tiny=wormhole.tiny)
         s_s = System.query.filter_by(name=wormhole.start).first()
         s_e = System.query.filter_by(name=wormhole.end).first()
         if s_s:

--- a/trackers/static/js/graph.js
+++ b/trackers/static/js/graph.js
@@ -28,7 +28,7 @@ function graph() {
         if (node.connections) {
             for (var i = 0; i < node.connections.length; i++) {
                 var child = node.connections[i];
-                drawLink(x, y, x + 100, y + newLines * rowHeight, child.eol, child.mass);
+                drawLink(x, y, x + 100, y + newLines * rowHeight, child.tiny, child.mass);
                 var stats = drawNode(child, x + 100, y + newLines * rowHeight);
                 newLines += stats[0];
                 newCols = Math.max(stats[1], newCols);
@@ -112,7 +112,7 @@ function graph() {
         sysCountText.on('click', _doClick);
         rect.on('click', _doClick);
     }
-    function drawLink(x1, y1, x2, y2, eol, mass) {
+    function drawLink(x1, y1, x2, y2, tiny, mass) {
         var color;
         if (mass == 'good')
             color = '#444';
@@ -127,9 +127,9 @@ function graph() {
             'y': 0,
             'points': [x1+rectWidth/2, y1, x2-rectWidth/2, y2],
             'stroke': color,
-            'strokeWidth': !window.WebSocket && eol ? 1 : 2,
-            'dashArray': [6, 3],
-            'dashArrayEnabled': Boolean(eol),
+            'strokeWidth': !window.WebSocket && tiny ? 1 : 2,
+            'dash': [3, 2, 0.001, 2],
+            'dashEnabled': Boolean(tiny),
         });
         layer.add(line);
     }


### PR DESCRIPTION
The KineticJS parameters for 'dashArray' and 'dashArrayEnabled'
were changed to 'dash' and 'dashEnabled' respectively in v5.1.0
For some reason the CloudFlare CDN serves v5.1.9 when we ask for
v5.0.6., so these settings are currently not working.

Also, as far as I can see the 'eol' member variable is never set
on the connection nodes (GraphWormhole objects), so it wouldn't
trigger anyway.

I therefore updated the parameters, and changed to draw thin dashed
lines for frigate holes instead since we've had requests for that.